### PR TITLE
isolate request callback from try/catch block

### DIFF
--- a/lib/google-books-search.js
+++ b/lib/google-books-search.js
@@ -174,17 +174,18 @@ var sendRequest = function(path, params, callback) {
         });
 
         response.on('end', function() {
+            var err, data;
             try {
-                var data = JSON.parse(body);
-
-                if (data.error) {
-                    callback(new Error(data.error.message));
-                } else {
-                    callback(null, data);
-                }
+                data = JSON.parse(body);
             } catch (e) {
-                callback(new Error('Invalid response from Google Books API.'));
+                err = new Error('Invalid response from Google Books API.');
             }
+            
+            if (data.error) {
+                callback(new Error(data.error.message));
+            } else {
+                callback(err, data);
+            }            
 
         });
     }).on('error', function(error) {


### PR DESCRIPTION
This fixes a bug that probably won't often be encountered, but the fix will hopefully save anyone in a similar situation from the debugging runaround that brought me here.

After an API response is received, the module attempts to parse the JSON, then sends the callback either the data or error from Google, all within a try block, with a catch in case the JSON parse fails. The problem is that when the callback is called from within the try block, any errors thrown as the stack grows will be caught by this module. As a result, the module would call the callback twice - once with the data and once with an error of 'Invalid response from Google Books API.' This makes debugging tricky, since one thinks the error is with the request/response when it's actually a problem further down the line.

By isolating the callback from the try block, only errors thrown in the module will be caught by the module.